### PR TITLE
Support for multiple shortcodes and regex bugfix

### DIFF
--- a/MarkupShortcodes.module
+++ b/MarkupShortcodes.module
@@ -4,7 +4,7 @@ class MarkupShortcodes extends WireData implements Module {
 	public static function getModuleInfo() {
 		return array(
 			'title' => 'Short Codes',
-			'version' => 1.06,
+			'version' => 1.04,
 			'summary' => 'Enables WordPress like shortcodes.',
 		  	'autoload' => false,
           	'singular' => true
@@ -37,7 +37,6 @@ class MarkupShortcodes extends WireData implements Module {
 			preg_match_all('/'.$pattern.'/', $text, $matches, PREG_SET_ORDER);
 
 			$return = array();
-
 			foreach($matches as $match) {
 				$item = array( "name" => $match[2] );
 				$item[$match[2]] = array_combine($keys, $match);
@@ -91,8 +90,7 @@ class MarkupShortcodes extends WireData implements Module {
 
 		foreach($shortcodes as $shortcode) {
 			$element = $shortcode[$shortcode['name']];
-			$safe_pattern = str_replace(array('[', ']', '/', '"', '\''), array('\\[', ']', '\\/', '\\"', '\\\''), $element['full']);
-
+			$safe_pattern = preg_quote($element['full']);
 			$content = preg_replace_callback('%'.$safe_pattern.'%s', (function ($matches) use ($shortcode_tags, $element) {
 				if($shortcode_tags[$element['name']]) {
 					return $shortcode_tags[$element['name']]($element['attributes']);

--- a/MarkupShortcodes.module
+++ b/MarkupShortcodes.module
@@ -3,14 +3,14 @@
 class MarkupShortcodes extends WireData implements Module {
 	public static function getModuleInfo() {
 		return array(
-			'title' => 'Short Codes', 
-			'version' => 1.04, 
-			'summary' => 'Enables WordPress like shortcodes.', 
+			'title' => 'Short Codes',
+			'version' => 1.06,
+			'summary' => 'Enables WordPress like shortcodes.',
 		  	'autoload' => false,
-          	'singular' => true 
-    	); 
+          	'singular' => true
+    	);
 	}
-          
+
 	public function init() {}
 
 	private $shortcode_tags = array();
@@ -18,11 +18,11 @@ class MarkupShortcodes extends WireData implements Module {
 	public function add($tag, $func) {
 		$this->shortcode_tags[$tag] = $func;
 	}
-	
+
 	public function remove($tag) {
 		unset($this->shortcode_tags[$tag]);
 	}
-	
+
 	public function remove_all() {
 		$this->shortcode_tags = array();
 	}
@@ -30,18 +30,23 @@ class MarkupShortcodes extends WireData implements Module {
 	private function get_shortcodes($text) {
 		if($this->shortcode_tags) {
 			$keys = array('full', 'extra_before', 'name', 'attributes', 'closing', 'content', 'extra_after');
+
 			$tags = implode('|', array_keys($this->shortcode_tags));
-			
+
 			$pattern = '\\[(\\[?)('.$tags.')\\b([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*+(?:\\[(?!\\/\\2\\])[^\\[]*+)*+)\\[\\/\\2\\])?)(\\]?)';
 			preg_match_all('/'.$pattern.'/', $text, $matches, PREG_SET_ORDER);
-			
+
+			$return = array();
+
 			foreach($matches as $match) {
-				$return[$match[2]] = array_combine($keys, $match);		
+				$item = array( "name" => $match[2] );
+				$item[$match[2]] = array_combine($keys, $match);
+				//$return[$match[2]] = array_combine($keys, $match);
 				$name = $match[2];
-						
+
 				$atts = array();
 				$pattern = '/(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*\'([^\']*)\'(?:\s|$)|(\w+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/';
-				$text = preg_replace("/[\x{00a0}\x{200b}]+/u", " ", $return[$name]['attributes']);
+				$text = preg_replace("/[\x{00a0}\x{200b}]+/u", " ", $item[$name]['attributes']);
 				if(preg_match_all($pattern, $text, $match, PREG_SET_ORDER)) {
 					foreach ($match as $m) {
 						if (!empty($m[1])) {
@@ -63,52 +68,55 @@ class MarkupShortcodes extends WireData implements Module {
 						$atts = ltrim($text);
 					}
 				}
-				
-				if($return[$name]['content']) {
-					$atts = array_merge(array('content' => $return[$name]['content']), (array)$atts);
+
+				if($item[$name]['content']) {
+					$atts = array_merge(array('content' => $item[$name]['content']), (array)$atts);
 				}
-				
-				$return[$name]['attributes'] = $atts;
+
+				$item[$name]['attributes'] = $atts;
+
+				array_push($return, $item);
 			}
-			
+
 			return $return;
 		} else {
 			return array();
 		}
 	}
-	
-	
+
+
 	public function render($content) {
 		$shortcode_tags = $this->shortcode_tags;
 		$shortcodes = $this->get_shortcodes($content);
 
 		foreach($shortcodes as $shortcode) {
-			$safe_pattern = str_replace(array('[', ']', '/', '"', '\''), array('\\[', ']', '\\/', '\\"', '\\\''), $shortcode['full']);
-			
-			$content = preg_replace_callback('%'.$safe_pattern.'%s', (function ($matches) use ($shortcode_tags, $shortcode) {
-				if($shortcode_tags[$shortcode['name']]) {
-					return $shortcode_tags[$shortcode['name']]($shortcode['attributes']);
+			$element = $shortcode[$shortcode['name']];
+			$safe_pattern = str_replace(array('[', ']', '/', '"', '\''), array('\\[', ']', '\\/', '\\"', '\\\''), $element['full']);
+
+			$content = preg_replace_callback('%'.$safe_pattern.'%s', (function ($matches) use ($shortcode_tags, $element) {
+				if($shortcode_tags[$element['name']]) {
+					return $shortcode_tags[$element['name']]($element['attributes']);
 				}
 			}), $content);
 		}
-	
+
 		return $content;
 	}
-	
+
 	public function format($content) {
 		$this->render($content);
 	}
-	
+
 	public function ___install() {
-	
+
 		if(ProcessWire::versionMajor == 2 && ProcessWire::versionMinor < 2) {
-			throw new WireException("This module requires ProcessWire 2.2 or newer."); 
+			throw new WireException("This module requires ProcessWire 2.2 or newer.");
 		}
-	
+
 		if(version_compare(PHP_VERSION, '5.3.0', '<')) {
-			throw new WireException("This module requires PHP 5.3 or newer."); 
+			throw new WireException("This module requires PHP 5.3 or newer.");
 		}
-	
+
 	}
 
 }


### PR DESCRIPTION
With this fix, it is possible to use one and the same shortcode more than one time. I also fixed a bug in the $safe_pattern logic. If you had a „?“ sign in the shortcode content - it broke.
